### PR TITLE
Safer check node version check.

### DIFF
--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -13,7 +13,7 @@ if (typeof Deno !== 'undefined') {
   // @ts-ignore
   baseUrl = new URL('file://' + Deno.cwd() + '/');
 }
-else if (typeof process !== 'undefined' && process.versions.node) {
+else if (typeof process !== 'undefined' && process.versions?.node) {
   baseUrl = new URL('file://' + process.cwd() + '/');
 }
 else if (typeof document as any !== 'undefined') {


### PR DESCRIPTION
I noticed an error when trying to use this package in a web environment. we happen to have a stubbed process object, but no versions object.

Would this make sense to improve the safety of this check?

PS: thanks for all your amazing libraries 🤩 