### PR TITLE
Make the package resolveable by Jest 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   },
   "type": "module",
   "exports": {
-    "source": "./lib/map.js",
-    "default": "./dist/map.js"
+    ".": {
+      "source": "./lib/map.js",
+      "default": "./dist/map.js"
+    }
   },
   "files": [
     "lib",


### PR DESCRIPTION
Jest 27 still has limited support for package exports (see https://github.com/facebook/jest/issues/9771). But they do support the "default" export although it has to be explicitly set as `"."`. I recon, it's not to big of a compromise if we get better support in the popular tool