### PR TITLE
Fix type error and add typedoc build step.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 package-lock.json
 lib
 dist
-
+docs

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -4,6 +4,11 @@ default-task = 'build'
 extensions = ['chomp@0.1:swc', 'chomp@0.1:rollup']
 
 [[task]]
+target = 'docs'
+deps = ['src/*.ts']
+run = 'typedoc src/*.ts'
+
+[[task]]
 dep = 'src/##.ts'
 target = 'lib/##.js'
 template = 'swc'

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.2.215",
-    "rollup": "^2.53.3"
+    "rollup": "^2.53.3",
+    "typedoc": "^0.23.24"
   }
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -32,7 +32,7 @@ export class ImportMap implements IImportMap {
    * @param opts import map options, can be an optional bag of { map?, mapUrl?, rootUrl? } or just a direct mapUrl
    */
   constructor (opts: { map?: IImportMap, mapUrl?: string | URL, rootUrl?: string | URL | null } | string | URL) {
-    let { map, mapUrl = baseUrl, rootUrl } = opts instanceof URL || typeof opts === 'string' || opts === undefined
+    let { map, mapUrl = baseUrl, rootUrl } = (opts instanceof URL || typeof opts === 'string' || typeof opts === 'undefined')
         ? { mapUrl: opts, map: undefined, rootUrl: undefined }
         : opts;
     if (typeof mapUrl === 'string')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "typeRoots": ["node_modules/@types"],
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "module": "esnext",
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "lib",
+    "declaration": true,
+    "removeComments": false
+  },
+  "include": [
+    "src/*.ts"
+  ]
+}


### PR DESCRIPTION
There's currently a type error in `map.ts` as none of the build steps do type
checking at the moment:

```
Error: node_modules/@jspm/import-map/src/map.ts:40:5 - error TS2322: Type 'URL | { map?: IImportMap; mapUrl?: string | URL; rootUrl?: string | URL; }' is not assignable to type 'URL'.
  Type '{ map?: IImportMap; mapUrl?: string | URL; rootUrl?: string | URL; }' is missing the following properties from type 'URL': hash, host, hostname, href, and 9 more.

40     this.mapUrl = mapUrl;
       ~~~~~~~~~~~
```

I've added a typedocs build step which does checking, so we should be able to
build docs upstream for the jspm generator and CLI now.
