### PR TITLE
fix: correctly resolve scopes in flatten() when rootUrl is set

### DIFF
--- a/src/url.ts
+++ b/src/url.ts
@@ -59,6 +59,8 @@ export function rebase (url: string, baseUrl: URL, rootUrl: URL | null = null) {
   }
   if (rootUrl && resolved.href.startsWith(rootUrl.href))
     return resolved.href.slice(rootUrl.href.length - 1);
+  if (rootUrl && rootUrl.href.startsWith(resolved.href)) // edge-case
+    return '/' + relative(resolved, baseUrl);
   if (sameOrigin(resolved, baseUrl))
     return relative(resolved, baseUrl);
   return resolved.href;

--- a/src/url.ts
+++ b/src/url.ts
@@ -59,8 +59,9 @@ export function rebase (url: string, baseUrl: URL, rootUrl: URL | null = null) {
   }
   if (rootUrl && resolved.href.startsWith(rootUrl.href))
     return resolved.href.slice(rootUrl.href.length - 1);
-  if (rootUrl && rootUrl.href.startsWith(resolved.href)) // edge-case
-    return '/' + relative(resolved, baseUrl);
+  if (rootUrl && rootUrl.href.startsWith(resolved.href)) {// edge-case
+    return '/' + relative(resolved, rootUrl);
+  }
   if (sameOrigin(resolved, baseUrl))
     return relative(resolved, baseUrl);
   return resolved.href;

--- a/test/cases/flattening-roots.js
+++ b/test/cases/flattening-roots.js
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { ImportMap } from '@jspm/import-map';
+
+
+const map = new ImportMap({
+  mapUrl: new URL("file:///test/map/"),
+  rootUrl: new URL("file:///test/"),
+  map: {
+    scopes: {
+      '/': {
+        'react': 'https://ga.jspm.io/npm:react@18.2.0/index.js',
+      }
+    }
+  }
+});
+
+map.flatten();
+assert(map.scopes && map.scopes["/"]);

--- a/test/cases/rebase-url.js
+++ b/test/cases/rebase-url.js
@@ -1,0 +1,7 @@
+import { rebase } from '../../lib/url.js';
+import assert from 'assert';
+
+const url = 'file:///test/';
+const mapUrl = new URL('file:///test/a/');
+const rootUrl = new URL('file:///test/a/');
+assert.equal(rebase(url, mapUrl, rootUrl), '/../');

--- a/test/cases/rebase-url.js
+++ b/test/cases/rebase-url.js
@@ -1,7 +1,12 @@
 import { rebase } from '../../lib/url.js';
 import assert from 'assert';
 
-const url = 'file:///test/';
-const mapUrl = new URL('file:///test/a/');
-const rootUrl = new URL('file:///test/a/');
+let url = 'file:///test/';
+let mapUrl = new URL('file:///test/a/');
+let rootUrl = new URL('file:///test/a/');
 assert.equal(rebase(url, mapUrl, rootUrl), '/../');
+
+url = 'file:///test/';
+mapUrl = new URL('file:///test/a/');
+rootUrl = new URL('file:///test/a/b/');
+assert.equal(rebase(url, mapUrl, rootUrl), '/../../');


### PR DESCRIPTION
Currently there's a bug when flattening with a root URL on the filesystem. I'll
attach a photo in the comments to illustrate; basically in a few places we're
"resolving" a relative URL by doing something like `new URL(rel, this.mapUrl)`,
which is fine so long as `rel` isn't a relative like `/`, in which case it
should resolve to the root.
