### PR TITLE
fix: handle relative URLs in flatten()

### DIFF
--- a/src/alphabetize.ts
+++ b/src/alphabetize.ts
@@ -1,6 +1,5 @@
-export function alphabetize<T> (obj: Record<string, T>): Record<string, T> {
+export function alphabetize<T>(obj: Record<string, T>): Record<string, T> {
   const out: Record<string, T> = {};
-  for (const key of Object.keys(obj).sort())
-    out[key] = obj[key];
+  for (const key of Object.keys(obj).sort()) out[key] = obj[key];
   return out;
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,5 +1,13 @@
-import { baseUrl, rebase, isPlain, isURL, getCommonBase, resolve, sameOrigin } from './url.js';
-import { alphabetize } from './alphabetize.js';
+import {
+  baseUrl,
+  rebase,
+  isPlain,
+  isURL,
+  getCommonBase,
+  resolve,
+  sameOrigin,
+} from "./url.js";
+import { alphabetize } from "./alphabetize.js";
 
 export interface IImportMap {
   imports?: Record<string, string>;
@@ -20,7 +28,7 @@ export class ImportMap implements IImportMap {
   /**
    * The URL to use for root-level resolutions in the import map
    * If null, root resolutions are not resolved and instead left as-is
-   * 
+   *
    * By default, rootUrl is null unless the mapUrl is an http or https URL,
    * in which case it is taken to be the root of the mapUrl.
    */
@@ -28,31 +36,48 @@ export class ImportMap implements IImportMap {
 
   /**
    * Create a new import map instance
-   * 
+   *
    * @param opts import map options, can be an optional bag of { map?, mapUrl?, rootUrl? } or just a direct mapUrl
    */
-  constructor (opts: { map?: IImportMap, mapUrl?: string | URL, rootUrl?: string | URL | null } | string | URL) {
-    let { map, mapUrl = baseUrl, rootUrl } = (opts instanceof URL || typeof opts === 'string' || typeof opts === 'undefined')
-        ? { mapUrl: opts, map: undefined, rootUrl: undefined }
-        : opts;
-    if (typeof mapUrl === 'string')
-      mapUrl = new URL(mapUrl);
+  constructor(
+    opts:
+      | {
+          map?: IImportMap;
+          mapUrl?: string | URL;
+          rootUrl?: string | URL | null;
+        }
+      | string
+      | URL
+  ) {
+    let {
+      map,
+      mapUrl = baseUrl,
+      rootUrl,
+    } = opts instanceof URL ||
+    typeof opts === "string" ||
+    typeof opts === "undefined"
+      ? { mapUrl: opts, map: undefined, rootUrl: undefined }
+      : opts;
+    if (typeof mapUrl === "string") mapUrl = new URL(mapUrl);
     this.mapUrl = mapUrl;
-    if (rootUrl === undefined && (this.mapUrl.protocol === 'http:' || this.mapUrl.protocol === 'https:'))
-      rootUrl = new URL('/', this.mapUrl);
-    else if (typeof rootUrl === 'string')
-      rootUrl = new URL(rootUrl);
+    if (
+      rootUrl === undefined &&
+      (this.mapUrl.protocol === "http:" || this.mapUrl.protocol === "https:")
+    )
+      rootUrl = new URL("/", this.mapUrl);
+    else if (typeof rootUrl === "string") rootUrl = new URL(rootUrl);
     this.rootUrl = rootUrl || null;
-    if (map)
-      this.extend(map);
+    if (map) this.extend(map);
   }
 
   /**
    * Clones the import map
    * @returns Cloned import map
    */
-  clone () {
-    return new ImportMap({ mapUrl: this.mapUrl, rootUrl: this.rootUrl }).extend(this);
+  clone() {
+    return new ImportMap({ mapUrl: this.mapUrl, rootUrl: this.rootUrl }).extend(
+      this
+    );
   }
 
   /**
@@ -61,14 +86,16 @@ export class ImportMap implements IImportMap {
    * @param overrideScopes Set to true to have scopes be replacing instead of extending
    * @returns ImportMap for chaining
    */
-  extend (map: IImportMap, overrideScopes = false) {
+  extend(map: IImportMap, overrideScopes = false) {
     Object.assign(this.imports, map.imports);
     if (overrideScopes) {
       Object.assign(this.scopes, map.scopes);
-    }
-    else if (map.scopes) {
+    } else if (map.scopes) {
       for (const scope of Object.keys(map.scopes))
-        Object.assign(this.scopes[scope] = this.scopes[scope] || Object.create(null), map.scopes[scope]);
+        Object.assign(
+          (this.scopes[scope] = this.scopes[scope] || Object.create(null)),
+          map.scopes[scope]
+        );
     }
     this.rebase();
     return this;
@@ -78,7 +105,7 @@ export class ImportMap implements IImportMap {
    * Performs an alphanumerical sort on the import map imports and scopes
    * @returns ImportMap for chaining
    */
-  sort () {
+  sort() {
     this.imports = alphabetize(this.imports);
     this.scopes = alphabetize(this.scopes);
     for (const scope of Object.keys(this.scopes))
@@ -88,17 +115,16 @@ export class ImportMap implements IImportMap {
 
   /**
    * Set a specific entry in the import map
-   * 
+   *
    * @param name Specifier to set
    * @param target Target of the map
    * @param parent Optional parent scope
    * @returns ImportMap for chaining
    */
-  set (name: string, target: string, parent?: string) {
+  set(name: string, target: string, parent?: string) {
     if (!parent) {
       this.imports[name] = target;
-    }
-    else {
+    } else {
       this.scopes[parent] = this.scopes[parent] || Object.create(null);
       this.scopes[parent][name] = target;
     }
@@ -108,33 +134,32 @@ export class ImportMap implements IImportMap {
   /**
    * Bulk replace URLs in the import map
    * Provide a URL ending in "/" to perform path replacements
-   * 
+   *
    * @param url {String} The URL to replace
    * @param newUrl {String} The URL to replace it with
    * @returns ImportMap for chaining
    */
-  replace (url: string, newUrl: string) {
-    const replaceSubpaths = url.endsWith('/');
-    if (!isURL(url))
-      throw new Error('URL remapping only supports URLs');
+  replace(url: string, newUrl: string) {
+    const replaceSubpaths = url.endsWith("/");
+    if (!isURL(url)) throw new Error("URL remapping only supports URLs");
     const newRelPkgUrl = rebase(newUrl, this.mapUrl, this.rootUrl);
     for (const impt of Object.keys(this.imports)) {
       const target = this.imports[impt];
-      if (replaceSubpaths && target.startsWith(url) || target === url)
-          this.imports[impt] = newRelPkgUrl + target.slice(url.length);
+      if ((replaceSubpaths && target.startsWith(url)) || target === url)
+        this.imports[impt] = newRelPkgUrl + target.slice(url.length);
     }
     for (const scope of Object.keys(this.scopes)) {
       const scopeImports = this.scopes[scope];
       const scopeUrl = resolve(scope, this.mapUrl, this.rootUrl);
-      if (replaceSubpaths && scopeUrl.startsWith(url) || scopeUrl === url) {
+      if ((replaceSubpaths && scopeUrl.startsWith(url)) || scopeUrl === url) {
         const newScope = newRelPkgUrl + scopeUrl.slice(url.length);
         delete this.scopes[scope];
         this.scopes[newScope] = scopeImports;
       }
       for (const impt of Object.keys(scopeImports)) {
         const target = scopeImports[impt];
-        if (replaceSubpaths && target.startsWith(url) || target === url)
-            scopeImports[impt] = newRelPkgUrl + target.slice(url.length);
+        if ((replaceSubpaths && target.startsWith(url)) || target === url)
+          scopeImports[impt] = newRelPkgUrl + target.slice(url.length);
       }
     }
     return this;
@@ -143,14 +168,14 @@ export class ImportMap implements IImportMap {
   /**
    * Groups subpath mappings into path mappings when multiple exact subpaths
    * exist under the same path.
-   * 
+   *
    * For two mappings like { "base/a.js": "/a.js", "base/b.js": "/b.js" },
    * these will be replaced with a single path mapping { "base/": "/" }.
    * Groupings are done throughout all import scopes individually.
-   * 
+   *
    * @returns ImportMap for chaining
    */
-  combineSubpaths () {
+  combineSubpaths() {
     // iterate possible bases and submappings, grouping bases greedily
     const combineSubpathMappings = (mappings: Record<string, string>) => {
       let outMappings: Record<string, string> = Object.create(null);
@@ -161,31 +186,48 @@ export class ImportMap implements IImportMap {
         let mapMatch;
         if (isPlain(impt)) {
           mapMatch = getMapMatch(impt, outMappings);
+        } else {
+          mapMatch =
+            getMapMatch(
+              (impt = rebase(impt, this.mapUrl, this.rootUrl)),
+              outMappings
+            ) ||
+            (this.rootUrl &&
+              getMapMatch(
+                (impt = rebase(impt, this.mapUrl, null)),
+                outMappings
+              )) ||
+            undefined;
         }
-        else {
-          mapMatch = getMapMatch(impt = rebase(impt, this.mapUrl, this.rootUrl), outMappings) ||
-              this.rootUrl && getMapMatch(impt = rebase(impt, this.mapUrl, null), outMappings) || undefined;
-        }
-        if (mapMatch && impt.slice(mapMatch.length) ===
-              resolve(target, this.mapUrl, this.rootUrl).slice(resolve(outMappings[mapMatch], this.mapUrl, this.rootUrl).length)) {
+        if (
+          mapMatch &&
+          impt.slice(mapMatch.length) ===
+            resolve(target, this.mapUrl, this.rootUrl).slice(
+              resolve(outMappings[mapMatch], this.mapUrl, this.rootUrl).length
+            )
+        ) {
           continue;
         }
-  
+
         let newbase = false;
-        const targetParts = mappings[impt].split('/');
-        const imptParts = impt.split('/');
+        const targetParts = mappings[impt].split("/");
+        const imptParts = impt.split("/");
         for (let j = imptParts.length - 1; j > 0; j--) {
-          const subpath = imptParts.slice(j).join('/');
-          const subpathTarget = targetParts.slice(targetParts.length - (imptParts.length - j)).join('/');
+          const subpath = imptParts.slice(j).join("/");
+          const subpathTarget = targetParts
+            .slice(targetParts.length - (imptParts.length - j))
+            .join("/");
           if (subpath !== subpathTarget) {
             outMappings[impt] = mappings[impt];
             break;
           }
-          const base = imptParts.slice(0, j).join('/') + '/';
-          if (outMappings[base])
-            continue;
-          const baseTarget = targetParts.slice(0, targetParts.length - (imptParts.length - j)).join('/') + '/';
-  
+          const base = imptParts.slice(0, j).join("/") + "/";
+          if (outMappings[base]) continue;
+          const baseTarget =
+            targetParts
+              .slice(0, targetParts.length - (imptParts.length - j))
+              .join("/") + "/";
+
           // Dedupe existing mappings against the new base to remove them
           // And if we dont dedupe against anything then dont perform this basing
           for (let impt of Object.keys(outMappings)) {
@@ -193,12 +235,22 @@ export class ImportMap implements IImportMap {
             let matches = false;
             if (isPlain(impt)) {
               matches = impt.startsWith(base);
+            } else {
+              matches =
+                (impt = rebase(impt, this.mapUrl, this.rootUrl)).startsWith(
+                  base
+                ) ||
+                (impt = rebase(impt, this.mapUrl, this.rootUrl)).startsWith(
+                  base
+                );
             }
-            else {
-              matches = (impt = rebase(impt, this.mapUrl, this.rootUrl)).startsWith(base) ||
-                  (impt = rebase(impt, this.mapUrl, this.rootUrl)).startsWith(base);
-            }
-            if (matches && impt.slice(base.length) === resolve(target, this.mapUrl, this.rootUrl).slice(resolve(baseTarget, this.mapUrl, this.rootUrl).length)) {
+            if (
+              matches &&
+              impt.slice(base.length) ===
+                resolve(target, this.mapUrl, this.rootUrl).slice(
+                  resolve(baseTarget, this.mapUrl, this.rootUrl).length
+                )
+            ) {
               newbase = true;
               delete outMappings[impt];
             }
@@ -210,8 +262,7 @@ export class ImportMap implements IImportMap {
           }
         }
 
-        if (!newbase)
-          outMappings[impt] = target;
+        if (!newbase) outMappings[impt] = target;
       }
       return outMappings;
     };
@@ -227,101 +278,130 @@ export class ImportMap implements IImportMap {
 
   /**
    * Groups the import map scopes to shared URLs to reduce duplicate mappings.
-   * 
+   *
    * For two given scopes, "https://site.com/x/" and "https://site.com/y/",
    * a single scope will be constructed for "https://site.com/" including
    * their shared mappings, only retaining the scopes if they have differences.
-   * 
+   *
    * In the case where the scope is on the same origin as the mapUrl, the grouped
    * scope is determined based on determining the common baseline over all local scopes
-   * 
+   *
    * @returns ImportMap for chaining
    */
-  flatten () {
+  flatten() {
     // First, determine the common base for the local mappings if any
     let localScopemapUrl: string | null = null;
-    for(const scope of Object.keys(this.scopes)) {
-      const scopeUrl = new URL(resolve(scope, this.mapUrl, this.rootUrl));
-      if (scopeUrl.protocol === this.mapUrl.protocol && scopeUrl.hostname === this.mapUrl.hostname && scopeUrl.port === this.mapUrl.port) {
-        if (!localScopemapUrl)
-          localScopemapUrl = scopeUrl.href;
-        else
-          localScopemapUrl = getCommonBase(scopeUrl.href, localScopemapUrl);
+    for (const scope of Object.keys(this.scopes)) {
+      const resolvedScope = resolve(scope, this.mapUrl, this.rootUrl);
+      if (isURL(resolvedScope)) {
+        const scopeUrl = new URL(resolvedScope);
+        if (sameOrigin(scopeUrl, this.mapUrl)) {
+          if (!localScopemapUrl) localScopemapUrl = scopeUrl.href;
+          else
+            localScopemapUrl = getCommonBase(scopeUrl.href, localScopemapUrl);
+        }
+      } else {
+        if (!localScopemapUrl) localScopemapUrl = resolvedScope;
+        else localScopemapUrl = getCommonBase(resolvedScope, localScopemapUrl);
       }
     }
 
-    const relativeLocalScopemapUrl = localScopemapUrl !== null ? rebase(localScopemapUrl, this.mapUrl, this.rootUrl) : null;
-
     // for each scope, update its mappings to be in the shared base where possible
+    const relativeLocalScopemapUrl = localScopemapUrl
+      ? rebase(localScopemapUrl, this.mapUrl, this.rootUrl)
+      : null;
     for (const scope of Object.keys(this.scopes)) {
       const scopeImports = this.scopes[scope];
 
-      const scopeUrl = new URL(resolve(scope, this.mapUrl, this.rootUrl));
-
       let scopemapUrl: string;
-      if (sameOrigin(scopeUrl, this.mapUrl)) {
-        scopemapUrl = relativeLocalScopemapUrl!;
-      }
-      else {
-        scopemapUrl = scopeUrl.protocol + '//' + scopeUrl.hostname + (scopeUrl.port ? ':' + scopeUrl.port : '') + '/';
+      const resolvedScope = resolve(scope, this.mapUrl, this.rootUrl);
+      if (isURL(resolvedScope)) {
+        const scopeUrl = new URL(resolvedScope);
+        if (sameOrigin(scopeUrl, this.mapUrl)) {
+          scopemapUrl = relativeLocalScopemapUrl;
+        } else {
+          scopemapUrl =
+            scopeUrl.protocol +
+            "//" +
+            scopeUrl.hostname +
+            (scopeUrl.port ? ":" + scopeUrl.port : "") +
+            "/";
+        }
+      } else {
+        scopemapUrl = relativeLocalScopemapUrl;
       }
 
-      let scopeBase: Record<string, string> | null = this.scopes[scopemapUrl] || Object.create(null);
+      let scopeBase: Record<string, string> | null =
+        this.scopes[scopemapUrl] || Object.create(null);
       if (scopeBase === scopeImports) scopeBase = null;
 
       let flattenedAll = true;
       for (const name of Object.keys(scopeImports)) {
         const target = scopeImports[name];
-        if (this.imports[name] && resolve(this.imports[name], this.mapUrl, this.rootUrl) === resolve(target, this.mapUrl, this.rootUrl)) {
+        if (
+          this.imports[name] &&
+          resolve(this.imports[name], this.mapUrl, this.rootUrl) ===
+            resolve(target, this.mapUrl, this.rootUrl)
+        ) {
           delete scopeImports[name];
-        }
-        else if (scopeBase && (!scopeBase[name] || resolve(scopeBase[name], this.mapUrl, this.rootUrl) === resolve(target, this.mapUrl, this.rootUrl))) {
+        } else if (
+          scopeBase &&
+          (!scopeBase[name] ||
+            resolve(scopeBase[name], this.mapUrl, this.rootUrl) ===
+              resolve(target, this.mapUrl, this.rootUrl))
+        ) {
           scopeBase[name] = rebase(target, this.mapUrl, this.rootUrl);
           delete scopeImports[name];
           this.scopes[<string>scopemapUrl] = alphabetize(scopeBase);
-        }
-        else {
+        } else {
           flattenedAll = false;
         }
       }
-      if (flattenedAll)
-        delete this.scopes[scope];
+      if (flattenedAll) delete this.scopes[scope];
     }
     return this;
   }
 
   /**
    * Rebase the entire import map to a new mapUrl and rootUrl
-   * 
+   *
    * If the rootUrl is not provided, it will remain null if it was
    * already set to null.
-   * 
+   *
    * Otherwise, just like the constructor options, the rootUrl
    * will default to the mapUrl base if it is an http: or https:
    * scheme URL, and null otherwise keeping absolute URLs entirely
    * in-tact.
-   * 
+   *
    * @param mapUrl The new map URL to use
    * @param rootUrl The new root URL to use
    * @returns ImportMap for chaining
    */
-  rebase (mapUrl: URL | string = this.mapUrl, rootUrl?: URL | string | null) {
-    if (typeof mapUrl === 'string')
-      mapUrl = new URL(mapUrl);
+  rebase(mapUrl: URL | string = this.mapUrl, rootUrl?: URL | string | null) {
+    if (typeof mapUrl === "string") mapUrl = new URL(mapUrl);
     if (rootUrl === undefined) {
-      if (mapUrl.href === this.mapUrl.href)
-        rootUrl = this.rootUrl;
+      if (mapUrl.href === this.mapUrl.href) rootUrl = this.rootUrl;
       else
-        rootUrl = this.rootUrl === null || mapUrl.protocol !== 'https:' && mapUrl.protocol !== 'http:' ? null : new URL('/', mapUrl);
-    }
-    else if (typeof rootUrl === 'string')
-      rootUrl = new URL(rootUrl);
+        rootUrl =
+          this.rootUrl === null ||
+          (mapUrl.protocol !== "https:" && mapUrl.protocol !== "http:")
+            ? null
+            : new URL("/", mapUrl);
+    } else if (typeof rootUrl === "string") rootUrl = new URL(rootUrl);
     let changedImportProps = false;
     for (const impt of Object.keys(this.imports)) {
       const target = this.imports[impt];
-      this.imports[impt] = rebase(resolve(target, this.mapUrl, this.rootUrl), mapUrl, rootUrl);
+      this.imports[impt] = rebase(
+        resolve(target, this.mapUrl, this.rootUrl),
+        mapUrl,
+        rootUrl
+      );
       if (!isPlain(impt)) {
-        const newImpt = rebase(resolve(impt, this.mapUrl, this.rootUrl), mapUrl, rootUrl);
+        const newImpt = rebase(
+          resolve(impt, this.mapUrl, this.rootUrl),
+          mapUrl,
+          rootUrl
+        );
         if (newImpt !== impt) {
           changedImportProps = true;
           this.imports[newImpt] = this.imports[impt];
@@ -329,17 +409,24 @@ export class ImportMap implements IImportMap {
         }
       }
     }
-    if (changedImportProps)
-      this.imports = alphabetize(this.imports);
+    if (changedImportProps) this.imports = alphabetize(this.imports);
     let changedScopeProps = false;
     for (const scope of Object.keys(this.scopes)) {
       const scopeImports = this.scopes[scope];
       let changedScopeImportProps = false;
       for (const impt of Object.keys(scopeImports)) {
         const target = scopeImports[impt];
-        scopeImports[impt] = rebase(resolve(target, this.mapUrl, this.rootUrl), mapUrl, rootUrl);
+        scopeImports[impt] = rebase(
+          resolve(target, this.mapUrl, this.rootUrl),
+          mapUrl,
+          rootUrl
+        );
         if (!isPlain(impt)) {
-          const newName = rebase(resolve(impt, this.mapUrl, this.rootUrl), mapUrl, rootUrl);
+          const newName = rebase(
+            resolve(impt, this.mapUrl, this.rootUrl),
+            mapUrl,
+            rootUrl
+          );
           if (newName !== impt) {
             changedScopeImportProps = true;
             scopeImports[newName] = scopeImports[impt];
@@ -349,15 +436,18 @@ export class ImportMap implements IImportMap {
       }
       if (changedScopeImportProps)
         this.scopes[scope] = alphabetize(scopeImports);
-      const newScope = rebase(resolve(scope, this.mapUrl, this.rootUrl), mapUrl, rootUrl);
+      const newScope = rebase(
+        resolve(scope, this.mapUrl, this.rootUrl),
+        mapUrl,
+        rootUrl
+      );
       if (scope !== newScope) {
         changedScopeProps = true;
         delete this.scopes[scope];
         this.scopes[newScope] = scopeImports;
       }
     }
-    if (changedScopeProps)
-      this.scopes = alphabetize(this.scopes);
+    if (changedScopeProps) this.scopes = alphabetize(this.scopes);
     this.mapUrl = mapUrl;
     this.rootUrl = rootUrl;
     return this;
@@ -365,52 +455,81 @@ export class ImportMap implements IImportMap {
 
   /**
    * Perform a module resolution against the import map
-   * 
+   *
    * @param specifier Specifier to resolve
    * @param parentUrl Parent URL to resolve against
    * @returns Resolved URL string
    */
-  resolve (specifier: string, parentUrl: string | URL = this.mapUrl): string {
-    if (typeof parentUrl !== 'string')
-      parentUrl = parentUrl.toString();
+  resolve(specifier: string, parentUrl: string | URL = this.mapUrl): string {
+    if (typeof parentUrl !== "string") parentUrl = parentUrl.toString();
     parentUrl = resolve(parentUrl, this.mapUrl, this.rootUrl);
     let specifierUrl: URL | undefined;
     if (!isPlain(specifier)) {
       specifierUrl = new URL(specifier, parentUrl);
       specifier = specifierUrl.href;
     }
-    const scopeMatches = getScopeMatches(parentUrl, this.scopes, this.mapUrl, this.rootUrl);
+    const scopeMatches = getScopeMatches(
+      parentUrl,
+      this.scopes,
+      this.mapUrl,
+      this.rootUrl
+    );
     for (const [scope] of scopeMatches) {
       let mapMatch = getMapMatch(specifier, this.scopes[scope]);
       if (!mapMatch && specifierUrl) {
-        mapMatch = getMapMatch(specifier = rebase(specifier, this.mapUrl, this.rootUrl), this.scopes[scope]) ||
-          this.rootUrl && getMapMatch(specifier = rebase(specifier, this.mapUrl, null), this.scopes[scope]) || undefined;
+        mapMatch =
+          getMapMatch(
+            (specifier = rebase(specifier, this.mapUrl, this.rootUrl)),
+            this.scopes[scope]
+          ) ||
+          (this.rootUrl &&
+            getMapMatch(
+              (specifier = rebase(specifier, this.mapUrl, null)),
+              this.scopes[scope]
+            )) ||
+          undefined;
       }
       if (mapMatch) {
         const target = this.scopes[scope][mapMatch];
-        return resolve(target + specifier.slice(mapMatch.length), this.mapUrl, this.rootUrl);
+        return resolve(
+          target + specifier.slice(mapMatch.length),
+          this.mapUrl,
+          this.rootUrl
+        );
       }
     }
     let mapMatch = getMapMatch(specifier, this.imports);
     if (!mapMatch && specifierUrl) {
-      mapMatch = getMapMatch(specifier = rebase(specifier, this.mapUrl, this.rootUrl), this.imports) ||
-          this.rootUrl && getMapMatch(specifier = rebase(specifier, this.mapUrl, null), this.imports) || undefined;
+      mapMatch =
+        getMapMatch(
+          (specifier = rebase(specifier, this.mapUrl, this.rootUrl)),
+          this.imports
+        ) ||
+        (this.rootUrl &&
+          getMapMatch(
+            (specifier = rebase(specifier, this.mapUrl, null)),
+            this.imports
+          )) ||
+        undefined;
     }
     if (mapMatch) {
       const target = this.imports[mapMatch];
-      return resolve(target + specifier.slice(mapMatch.length), this.mapUrl, this.rootUrl);
+      return resolve(
+        target + specifier.slice(mapMatch.length),
+        this.mapUrl,
+        this.rootUrl
+      );
     }
-    if (specifierUrl)
-      return specifierUrl.href;
+    if (specifierUrl) return specifierUrl.href;
     throw new Error(`Unable to resolve ${specifier} in ${parentUrl}`);
   }
 
   /**
    * Get the import map JSON data
-   * 
+   *
    * @returns Import map data
    */
-  toJSON (): IImportMap {
+  toJSON(): IImportMap {
     const obj: any = {};
     if (Object.keys(this.imports).length) obj.imports = this.imports;
     if (Object.keys(this.scopes).length) obj.scopes = this.scopes;
@@ -418,24 +537,39 @@ export class ImportMap implements IImportMap {
   }
 }
 
-export function getScopeMatches (parentUrl: string, scopes: Record<string, Record<string, string>>, mapUrl: URL, rootUrl?: URL): [string, string][] {
-  let scopeCandidates = Object.keys(scopes).map(scope => [scope, resolve(scope, mapUrl, rootUrl)]);
-  scopeCandidates = scopeCandidates.sort(([, matchA], [, matchB]) => matchA.length < matchB.length ? 1 : -1);
+export function getScopeMatches(
+  parentUrl: string,
+  scopes: Record<string, Record<string, string>>,
+  mapUrl: URL,
+  rootUrl?: URL
+): [string, string][] {
+  let scopeCandidates = Object.keys(scopes).map((scope) => [
+    scope,
+    resolve(scope, mapUrl, rootUrl),
+  ]);
+  scopeCandidates = scopeCandidates.sort(([, matchA], [, matchB]) =>
+    matchA.length < matchB.length ? 1 : -1
+  );
 
   return scopeCandidates.filter(([, scopeUrl]) => {
-    return scopeUrl === parentUrl || scopeUrl.endsWith('/') && parentUrl.startsWith(scopeUrl);
+    return (
+      scopeUrl === parentUrl ||
+      (scopeUrl.endsWith("/") && parentUrl.startsWith(scopeUrl))
+    );
   }) as [string, string][];
 }
 
-export function getMapMatch<T = any> (specifier: string, map: Record<string, T>): string | undefined {
+export function getMapMatch<T = any>(
+  specifier: string,
+  map: Record<string, T>
+): string | undefined {
   if (specifier in map) return specifier;
   let curMatch;
   for (const match of Object.keys(map)) {
-    const wildcard = match.endsWith('*');
-    if (!match.endsWith('/') && !wildcard) continue;
+    const wildcard = match.endsWith("*");
+    if (!match.endsWith("/") && !wildcard) continue;
     if (specifier.startsWith(wildcard ? match.slice(0, -1) : match)) {
-      if (!curMatch || match.length > curMatch.length)
-        curMatch = match;
+      if (!curMatch || match.length > curMatch.length) curMatch = match;
     }
   }
   return curMatch;

--- a/src/url.ts
+++ b/src/url.ts
@@ -9,93 +9,102 @@ declare global {
 
 export let baseUrl: URL;
 // @ts-ignore
-if (typeof Deno !== 'undefined') {
+if (typeof Deno !== "undefined") {
   // @ts-ignore
-  baseUrl = new URL('file://' + Deno.cwd() + '/');
-}
-else if (typeof process !== 'undefined' && process.versions?.node) {
-  baseUrl = new URL('file://' + process.cwd() + '/');
-}
-else if (typeof document as any !== 'undefined') {
-  const baseEl: any | null = document.querySelector('base[href]');
+  baseUrl = new URL("file://" + Deno.cwd() + "/");
+} else if (typeof process !== "undefined" && process.versions?.node) {
+  baseUrl = new URL("file://" + process.cwd() + "/");
+} else if ((typeof document as any) !== "undefined") {
+  const baseEl: any | null = document.querySelector("base[href]");
   if (baseEl)
-    baseUrl = new URL(baseEl.href + (baseEl.href.endsWith('/') ? '' : '/'));
-  else if (typeof location !== 'undefined')
-    baseUrl = new URL('../', new URL(location.href));
+    baseUrl = new URL(baseEl.href + (baseEl.href.endsWith("/") ? "" : "/"));
+  else if (typeof location !== "undefined")
+    baseUrl = new URL("../", new URL(location.href));
 }
 
-export function getCommonBase (a: string, b: string): string {
-  if (a.startsWith(b))
-    return b;
-  if (b.startsWith(a))
-    return a;
-  const aSegments = a.split('/');
-  const bSegments = b.split('/');
+export function getCommonBase(a: string, b: string): string {
+  if (a.startsWith(b)) return b;
+  if (b.startsWith(a)) return a;
+  const aSegments = a.split("/");
+  const bSegments = b.split("/");
   let i = 0;
-  while (aSegments[i] === bSegments[i])
-    i++;
-  return aSegments.slice(0, i).join('/') + '/';
+  while (aSegments[i] === bSegments[i]) i++;
+  return aSegments.slice(0, i).join("/") + "/";
 }
 
-export function sameOrigin (url: URL, baseUrl: URL) {
-  return url.protocol === baseUrl.protocol && url.host === baseUrl.host && url.port === baseUrl.port && url.username === baseUrl.username && url.password === baseUrl.password;
+export function sameOrigin(url: URL, baseUrl: URL) {
+  return (
+    url.protocol === baseUrl.protocol &&
+    url.host === baseUrl.host &&
+    url.port === baseUrl.port &&
+    url.username === baseUrl.username &&
+    url.password === baseUrl.password
+  );
 }
 
-export function resolve (url: string, mapUrl: URL, rootUrl: URL | null): string {
-  if (url.startsWith('/'))
-    return rootUrl ? new URL('.' + url.slice(url[1] === '/' ? 1 : 0), rootUrl).href : url;
+export function resolve(url: string, mapUrl: URL, rootUrl: URL | null): string {
+  if (url.startsWith("/"))
+    return rootUrl
+      ? new URL("." + url.slice(url[1] === "/" ? 1 : 0), rootUrl).href
+      : url;
   return new URL(url, mapUrl).href;
 }
 
-export function rebase (url: string, baseUrl: URL, rootUrl: URL | null = null) {
+export function rebase(url: string, baseUrl: URL, rootUrl: URL | null = null) {
   let resolved;
-  if (url.startsWith('/') || url.startsWith('//')) {
-    if (rootUrl === null)
-      return url;
+  if (url.startsWith("/") || url.startsWith("//")) {
+    if (rootUrl === null) return url;
     resolved = new URL(url, rootUrl);
-  }
-  else {
+  } else {
     resolved = new URL(url, baseUrl);
   }
   if (rootUrl && resolved.href.startsWith(rootUrl.href))
     return resolved.href.slice(rootUrl.href.length - 1);
-  if (rootUrl && rootUrl.href.startsWith(resolved.href)) {// edge-case
-    return '/' + relative(resolved, rootUrl);
+  if (rootUrl && rootUrl.href.startsWith(resolved.href)) {
+    // edge-case
+    return "/" + relative(resolved, rootUrl);
   }
-  if (sameOrigin(resolved, baseUrl))
-    return relative(resolved, baseUrl);
+  if (sameOrigin(resolved, baseUrl)) return relative(resolved, baseUrl);
   return resolved.href;
 }
 
-export function relative (url: URL, baseUrl: URL) {
+export function relative(url: URL, baseUrl: URL) {
   const baseUrlPath = baseUrl.pathname;
   const urlPath = url.pathname;
   const minLen = Math.min(baseUrlPath.length, urlPath.length);
   let sharedBaseIndex = -1;
   for (let i = 0; i < minLen; i++) {
     if (baseUrlPath[i] !== urlPath[i]) break;
-    if (urlPath[i] === '/') sharedBaseIndex = i;
+    if (urlPath[i] === "/") sharedBaseIndex = i;
   }
-  const backtracks = baseUrlPath.slice(sharedBaseIndex + 1).split('/').length - 1;
-  return (backtracks ? '../'.repeat(backtracks) : './') + urlPath.slice(sharedBaseIndex + 1) + url.search + url.hash;
+  const backtracks =
+    baseUrlPath.slice(sharedBaseIndex + 1).split("/").length - 1;
+  return (
+    (backtracks ? "../".repeat(backtracks) : "./") +
+    urlPath.slice(sharedBaseIndex + 1) +
+    url.search +
+    url.hash
+  );
 }
 
-export function isURL (specifier: string) {
+export function isURL(specifier: string) {
   try {
-    if (specifier[0] === '#')
-      return false;
+    if (specifier[0] === "#") return false;
     new URL(specifier);
-  }
-  catch {
+  } catch {
     return false;
   }
   return true;
 }
 
-export function isPlain (specifier: string) {
+export function isPlain(specifier: string) {
   return !isRelative(specifier) && !isURL(specifier);
 }
 
-export function isRelative (specifier: string) {
-  return specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('/');
+export function isRelative(specifier: string) {
+  return (
+    specifier.startsWith("./") ||
+    specifier.startsWith("../") ||
+    specifier.startsWith("/")
+  );
 }

--- a/test/cases/flattening-roots.js
+++ b/test/cases/flattening-roots.js
@@ -1,18 +1,69 @@
 import assert from 'assert';
 import { ImportMap } from '@jspm/import-map';
 
-
-const map = new ImportMap({
-  mapUrl: new URL("file:///test/map/"),
-  rootUrl: new URL("file:///test/"),
-  map: {
-    scopes: {
-      '/': {
-        'react': 'https://ga.jspm.io/npm:react@18.2.0/index.js',
+{
+  const map = new ImportMap({
+    mapUrl: new URL("file:///test/map/"),
+    rootUrl: new URL("file:///test/"),
+    map: {
+      scopes: {
+        '/': {
+          'react': 'https://ga.jspm.io/npm:react@18.2.0/index.js',
+        }
       }
     }
-  }
-});
+  });
 
-map.flatten();
-assert(map.scopes && map.scopes["/"]);
+  map.flatten();
+  assert(map.scopes && map.scopes["/"]);
+}
+
+{
+  const map = new ImportMap({
+    mapUrl: new URL(import.meta.url),
+    map: {
+      imports: {
+        '@patternfly/pfe-core': '/assets/packages/@patternfly/pfe-core/core.js',
+        '@rhds/tokens': '/assets/packages/@rhds/tokens/js/tokens.js',
+        '@lit/reactive-element': '/assets/packages/@lit/reactive-element/reactive-element.js',
+        lit: '/assets/packages/lit/index.js',
+        '@patternfly/elements/pf-tooltip/pf-tooltip.js': '/assets/packages/@patternfly/elements/pf-tooltip/pf-tooltip.js',
+        '@patternfly/pfe-core/controllers/roving-tabindex-controller.js': '/assets/packages/@patternfly/pfe-core/controllers/roving-tabindex-controller.js'
+      },
+      scopes: {
+        '/assets/packages/@patternfly/elements/': {
+          'lit/directives/class-map.js': '/assets/packages/lit/directives/class-map.js',
+          '@floating-ui/dom': '/assets/packages/@floating-ui/dom/dist/floating-ui.dom.browser.min.mjs',
+          '@patternfly/pfe-core/controllers/floating-dom-controller.js': '/assets/packages/@patternfly/pfe-core/controllers/floating-dom-controller.js',
+        },
+        '/assets/packages/lit/': {
+          'lit-element/lit-element.js': '/assets/packages/lit-element/lit-element.js',
+          '@lit/reactive-element/decorators/state.js': '/assets/packages/@lit/reactive-element/decorators/state.js',
+        },
+      }
+    }
+  });
+  map.flatten();
+  assert.deepStrictEqual(
+    map.toJSON(),
+    {
+      imports: {
+        '@patternfly/pfe-core': '/assets/packages/@patternfly/pfe-core/core.js',
+        '@rhds/tokens': '/assets/packages/@rhds/tokens/js/tokens.js',
+        '@lit/reactive-element': '/assets/packages/@lit/reactive-element/reactive-element.js',
+        lit: '/assets/packages/lit/index.js',
+        '@patternfly/elements/pf-tooltip/pf-tooltip.js': '/assets/packages/@patternfly/elements/pf-tooltip/pf-tooltip.js',
+        '@patternfly/pfe-core/controllers/roving-tabindex-controller.js': '/assets/packages/@patternfly/pfe-core/controllers/roving-tabindex-controller.js'
+      },
+      scopes: {
+        '/assets/packages/': {
+          'lit/directives/class-map.js': '/assets/packages/lit/directives/class-map.js',
+          '@floating-ui/dom': '/assets/packages/@floating-ui/dom/dist/floating-ui.dom.browser.min.mjs',
+          '@patternfly/pfe-core/controllers/floating-dom-controller.js': '/assets/packages/@patternfly/pfe-core/controllers/floating-dom-controller.js',
+          'lit-element/lit-element.js': '/assets/packages/lit-element/lit-element.js',
+          '@lit/reactive-element/decorators/state.js': '/assets/packages/@lit/reactive-element/decorators/state.js',
+        },
+      }
+    }
+  );
+}

--- a/test/cases/flattening.js
+++ b/test/cases/flattening.js
@@ -17,22 +17,22 @@ import { deepStrictEqual } from 'assert';
           'react-toastify': 'https://ga.jspm.io/npm:react-toastify@8.0.3/dist/index.js',
           '@tippyjs/react/headless': 'https://ga.jspm.io/npm:@tippyjs/react@4.2.6/headless/dist/dev.tippy-react-headless.umd.js',
           'tippy.js/headless': 'https://ga.jspm.io/npm:tippy.js@6.3.3/headless/dist/dev.tippy-headless.cjs.js',
-          '@roundforest/react-map-slots': './packages/commons/react-map-slots/src/map-slots.js',  
-          '@roundforest/react-tooltip': './packages/commons/react-tooltip/lib/src/tooltip.js',    
+          '@roundforest/react-map-slots': './packages/commons/react-map-slots/src/map-slots.js',
+          '@roundforest/react-tooltip': './packages/commons/react-tooltip/lib/src/tooltip.js',
           'react-dom': 'https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js',
           'react-copy-to-clipboard': 'https://ga.jspm.io/npm:react-copy-to-clipboard@5.0.4/lib/index.js'
         },
         './packages/bio/bio-home-page/': {
           '@roundforest/react-localization-commons': './packages/commons/react-localization-commons/lib/src/localization-commons.js',
           react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
-          '@roundforest/bio-design-system': './packages/bio/bio-design-system/lib/exports.js',    
+          '@roundforest/bio-design-system': './packages/bio/bio-design-system/lib/exports.js',
           '@roundforest/emotion-styled': './packages/commons/emotion-styled/src/emotion-styled.js',
           '@roundforest/bio-product-category-search': './packages/bio/bio-product-category-search/lib/src/exports.js',
           '@roundforest/react-environment-context': './packages/commons/react-environment-context/lib/src/react-environment-context.js',
           '@emotion/react': 'https://ga.jspm.io/npm:@emotion/react@11.5.0/dist/dev.emotion-react.browser.cjs.js',
           'react-helmet': 'https://ga.jspm.io/npm:react-helmet@6.1.0/lib/dev.Helmet.js',
           'react-dom': 'https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js',
-          '@roundforest/bio-home-page': './packages/bio/bio-home-page/lib/src/bio-home-page.js'   
+          '@roundforest/bio-home-page': './packages/bio/bio-home-page/lib/src/bio-home-page.js'
         },
         './packages/bio/bio-product-category-search/': {
           '@roundforest/react-localization-commons': './packages/commons/react-localization-commons/lib/src/localization-commons.js',
@@ -41,7 +41,7 @@ import { deepStrictEqual } from 'assert';
           react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
           '@emotion/react': 'https://ga.jspm.io/npm:@emotion/react@11.5.0/dist/dev.emotion-react.browser.cjs.js',
           '@roundforest/emotion-styled': './packages/commons/emotion-styled/src/emotion-styled.js',
-          '@roundforest/bio-design-system': './packages/bio/bio-design-system/lib/exports.js',    
+          '@roundforest/bio-design-system': './packages/bio/bio-design-system/lib/exports.js',
           '@roundforest/react-full-screen-state': './packages/commons/react-full-screen-state/lib/src/react-full-screen-state.js'
         },
         './packages/commons/emotion-styled/': {
@@ -63,11 +63,12 @@ import { deepStrictEqual } from 'assert';
         './packages/commons/react-ripple-effect/': {
           '@emotion/react': 'https://ga.jspm.io/npm:@emotion/react@11.5.0/dist/dev.emotion-react.browser.cjs.js',
           react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
-          '@roundforest/emotion-styled': './packages/commons/emotion-styled/src/emotion-styled.js'    },
+          '@roundforest/emotion-styled': './packages/commons/emotion-styled/src/emotion-styled.js'
+        },
         './packages/commons/react-tooltip/': {
           react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
           '@roundforest/emotion-styled': './packages/commons/emotion-styled/src/emotion-styled.js',
-          '@roundforest/react-portal': './packages/commons/react-portal/lib/src/portal.js'        
+          '@roundforest/react-portal': './packages/commons/react-portal/lib/src/portal.js'
         },
         'https://ga.jspm.io/npm:react-dom@16.14.0/': { react: 'https://ga.jspm.io/npm:react@16.14.0/dev.index.js' },
         'https://ga.jspm.io/npm:react-dom@17.0.2/': {
@@ -82,7 +83,7 @@ import { deepStrictEqual } from 'assert';
           '@babel/runtime/helpers/inheritsLoose': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/inheritsLoose.js',
           '@babel/runtime/helpers/interopRequireDefault': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/interopRequireDefault.js',
           '@emotion/cache': 'https://ga.jspm.io/npm:@emotion/cache@11.5.0/dist/dev.emotion-cache.browser.cjs.js',
-          '@emotion/hash': 'https://ga.jspm.io/npm:@emotion/hash@0.8.0/dist/hash.browser.cjs.js', 
+          '@emotion/hash': 'https://ga.jspm.io/npm:@emotion/hash@0.8.0/dist/hash.browser.cjs.js',
           '@emotion/is-prop-valid': 'https://ga.jspm.io/npm:@emotion/is-prop-valid@1.1.0/dist/emotion-is-prop-valid.browser.cjs.js',
           '@emotion/memoize': 'https://ga.jspm.io/npm:@emotion/memoize@0.7.5/dist/emotion-memoize.browser.cjs.js',
           '@emotion/react': 'https://ga.jspm.io/npm:@emotion/react@11.5.0/dist/dev.emotion-react.browser.cjs.js',
@@ -91,7 +92,7 @@ import { deepStrictEqual } from 'assert';
           '@emotion/unitless': 'https://ga.jspm.io/npm:@emotion/unitless@0.7.5/dist/unitless.browser.cjs.js',
           '@emotion/utils': 'https://ga.jspm.io/npm:@emotion/utils@1.0.0/dist/emotion-utils.browser.cjs.js',
           '@emotion/weak-memoize': 'https://ga.jspm.io/npm:@emotion/weak-memoize@0.2.5/dist/weak-memoize.browser.cjs.js',
-          '@popperjs/core': 'https://ga.jspm.io/npm:@popperjs/core@2.10.2/dist/cjs/dev.popper.js',      clsx: 'https://ga.jspm.io/npm:clsx@1.1.1/dist/clsx.js',
+          '@popperjs/core': 'https://ga.jspm.io/npm:@popperjs/core@2.10.2/dist/cjs/dev.popper.js', clsx: 'https://ga.jspm.io/npm:clsx@1.1.1/dist/clsx.js',
           'copy-to-clipboard': 'https://ga.jspm.io/npm:copy-to-clipboard@3.3.1/index.js',
           'hoist-non-react-statics': 'https://ga.jspm.io/npm:hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.cjs.js',
           'object-assign': 'https://ga.jspm.io/npm:object-assign@4.1.1/index.js',
@@ -99,9 +100,9 @@ import { deepStrictEqual } from 'assert';
           'prop-types/checkPropTypes': 'https://ga.jspm.io/npm:prop-types@15.7.2/dev.checkPropTypes.js',
           react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
           'react-dom': 'https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js',
-          'react-fast-compare': 'https://ga.jspm.io/npm:react-fast-compare@3.2.0/index.js',       
+          'react-fast-compare': 'https://ga.jspm.io/npm:react-fast-compare@3.2.0/index.js',
           'react-is': 'https://ga.jspm.io/npm:react-is@16.13.1/dev.index.js',
-          'react-side-effect': 'https://ga.jspm.io/npm:react-side-effect@2.1.1/lib/index.js',     
+          'react-side-effect': 'https://ga.jspm.io/npm:react-side-effect@2.1.1/lib/index.js',
           scheduler: 'https://ga.jspm.io/npm:scheduler@0.19.1/dev.index.js',
           'scheduler/tracing': 'https://ga.jspm.io/npm:scheduler@0.19.1/dev.tracing.js',
           stylis: 'https://ga.jspm.io/npm:stylis@4.0.10/dist/umd/stylis.js',
@@ -123,7 +124,7 @@ import { deepStrictEqual } from 'assert';
         'react-dom': 'https://ga.jspm.io/npm:react-dom@16.14.0/dev.index.js'
       },
       'https://ga.jspm.io/': {
-        '@babel/runtime/helpers/extends': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/extends.js',  
+        '@babel/runtime/helpers/extends': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/extends.js',
         '@babel/runtime/helpers/inheritsLoose': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/inheritsLoose.js',
         '@babel/runtime/helpers/interopRequireDefault': 'https://ga.jspm.io/npm:@babel/runtime@7.16.0/helpers/interopRequireDefault.js',
         '@emotion/cache': 'https://ga.jspm.io/npm:@emotion/cache@11.5.0/dist/dev.emotion-cache.browser.cjs.js',
@@ -132,8 +133,8 @@ import { deepStrictEqual } from 'assert';
         '@emotion/memoize': 'https://ga.jspm.io/npm:@emotion/memoize@0.7.5/dist/emotion-memoize.browser.cjs.js',
         '@emotion/react': 'https://ga.jspm.io/npm:@emotion/react@11.5.0/dist/dev.emotion-react.browser.cjs.js',
         '@emotion/serialize': 'https://ga.jspm.io/npm:@emotion/serialize@1.0.2/dist/dev.emotion-serialize.browser.cjs.js',
-        '@emotion/sheet': 'https://ga.jspm.io/npm:@emotion/sheet@1.0.3/dist/dev.emotion-sheet.browser.cjs.js',        '@emotion/unitless': 'https://ga.jspm.io/npm:@emotion/unitless@0.7.5/dist/unitless.browser.cjs.js',   
-        '@emotion/utils': 'https://ga.jspm.io/npm:@emotion/utils@1.0.0/dist/emotion-utils.browser.cjs.js',    
+        '@emotion/sheet': 'https://ga.jspm.io/npm:@emotion/sheet@1.0.3/dist/dev.emotion-sheet.browser.cjs.js', '@emotion/unitless': 'https://ga.jspm.io/npm:@emotion/unitless@0.7.5/dist/unitless.browser.cjs.js',
+        '@emotion/utils': 'https://ga.jspm.io/npm:@emotion/utils@1.0.0/dist/emotion-utils.browser.cjs.js',
         '@emotion/weak-memoize': 'https://ga.jspm.io/npm:@emotion/weak-memoize@0.2.5/dist/weak-memoize.browser.cjs.js',
         '@popperjs/core': 'https://ga.jspm.io/npm:@popperjs/core@2.10.2/dist/cjs/dev.popper.js',
         clsx: 'https://ga.jspm.io/npm:clsx@1.1.1/dist/clsx.js',
@@ -141,7 +142,7 @@ import { deepStrictEqual } from 'assert';
         'hoist-non-react-statics': 'https://ga.jspm.io/npm:hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.cjs.js',
         'object-assign': 'https://ga.jspm.io/npm:object-assign@4.1.1/index.js',
         'prop-types': 'https://ga.jspm.io/npm:prop-types@15.7.2/dev.index.js',
-        'prop-types/checkPropTypes': 'https://ga.jspm.io/npm:prop-types@15.7.2/dev.checkPropTypes.js',        
+        'prop-types/checkPropTypes': 'https://ga.jspm.io/npm:prop-types@15.7.2/dev.checkPropTypes.js',
         react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
         'react-dom': 'https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js',
         'react-fast-compare': 'https://ga.jspm.io/npm:react-fast-compare@3.2.0/index.js',
@@ -150,7 +151,7 @@ import { deepStrictEqual } from 'assert';
         scheduler: 'https://ga.jspm.io/npm:scheduler@0.19.1/dev.index.js',
         'scheduler/tracing': 'https://ga.jspm.io/npm:scheduler@0.19.1/dev.tracing.js',
         stylis: 'https://ga.jspm.io/npm:stylis@4.0.10/dist/umd/stylis.js',
-        'tippy.js/headless': 'https://ga.jspm.io/npm:tippy.js@6.3.3/headless/dist/dev.tippy-headless.cjs.js', 
+        'tippy.js/headless': 'https://ga.jspm.io/npm:tippy.js@6.3.3/headless/dist/dev.tippy-headless.cjs.js',
         'toggle-selection': 'https://ga.jspm.io/npm:toggle-selection@1.0.6/index.js'
       },
       './packages/': {
@@ -171,13 +172,13 @@ import { deepStrictEqual } from 'assert';
         '@roundforest/react-tooltip': './packages/commons/react-tooltip/lib/src/tooltip.js',
         '@tippyjs/react/headless': 'https://ga.jspm.io/npm:@tippyjs/react@4.2.6/headless/dist/dev.tippy-react-headless.umd.js',
         react: 'https://ga.jspm.io/npm:react@17.0.2/dev.index.js',
-        'react-copy-to-clipboard': 'https://ga.jspm.io/npm:react-copy-to-clipboard@5.0.4/lib/index.js',       
+        'react-copy-to-clipboard': 'https://ga.jspm.io/npm:react-copy-to-clipboard@5.0.4/lib/index.js',
         'react-dom': 'https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js',
         'react-helmet': 'https://ga.jspm.io/npm:react-helmet@6.1.0/lib/dev.Helmet.js',
         'react-is': 'https://ga.jspm.io/npm:react-is@17.0.2/dev.index.js',
         'react-query': 'https://ga.jspm.io/npm:react-query@3.31.0/lib/dev.index.js',
         'react-toastify': 'https://ga.jspm.io/npm:react-toastify@8.0.3/dist/index.js',
-        'tippy.js/headless': 'https://ga.jspm.io/npm:tippy.js@6.3.3/headless/dist/dev.tippy-headless.cjs.js'  
+        'tippy.js/headless': 'https://ga.jspm.io/npm:tippy.js@6.3.3/headless/dist/dev.tippy-headless.cjs.js'
       }
     }
   });
@@ -192,7 +193,7 @@ import { deepStrictEqual } from 'assert';
         '../../': {
           url: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/url.js',
           fs: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/fs.js',
-          '@babel/preset-typescript': 'https://ga.jspm.io/npm:@babel/preset-typescript@7.16.0/lib/index.js',      
+          '@babel/preset-typescript': 'https://ga.jspm.io/npm:@babel/preset-typescript@7.16.0/lib/index.js',
           '@babel/core': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/dev.index.js',
           '#fetch': '../../dist/fetch-native.js',
           'es-module-lexer': 'https://ga.jspm.io/npm:es-module-lexer@0.9.3/dist/lexer.js',
@@ -218,7 +219,7 @@ import { deepStrictEqual } from 'assert';
           '#lib/config/files/index.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/config/files/index-browser.js',
           '#lib/config/resolve-targets.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/config/resolve-targets-browser.js',
           '#lib/transformation/util/clone-deep.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transformation/util/clone-deep-browser.js',
-          '#lib/transform-file.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transform-file-browser.js',    
+          '#lib/transform-file.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transform-file-browser.js',
           process: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/process.js',
           path: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/path.js',
           fs: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/fs.js',
@@ -244,7 +245,7 @@ import { deepStrictEqual } from 'assert';
           browserslist: 'https://ga.jspm.io/npm:browserslist@4.17.4/index.js'
         },
         'https://ga.jspm.io/npm:@babel/helper-create-class-features-plugin@7.16.0/': {
-          '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js',      '@babel/helper-split-export-declaration': 'https://ga.jspm.io/npm:@babel/helper-split-export-declaration@7.16.0/lib/index.js',
+          '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js', '@babel/helper-split-export-declaration': 'https://ga.jspm.io/npm:@babel/helper-split-export-declaration@7.16.0/lib/index.js',
           '@babel/core': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/dev.index.js',
           '@babel/helper-replace-supers': 'https://ga.jspm.io/npm:@babel/helper-replace-supers@7.16.0/lib/index.js',
           '@babel/helper-member-expression-to-functions': 'https://ga.jspm.io/npm:@babel/helper-member-expression-to-functions@7.16.0/lib/index.js',
@@ -277,7 +278,7 @@ import { deepStrictEqual } from 'assert';
           '@babel/types': 'https://ga.jspm.io/npm:@babel/types@7.16.0/lib/index.js',
           '@babel/template': 'https://ga.jspm.io/npm:@babel/template@7.16.0/lib/index.js',
           '@babel/traverse': 'https://ga.jspm.io/npm:@babel/traverse@7.16.0/lib/index.js',
-          '@babel/helper-simple-access': 'https://ga.jspm.io/npm:@babel/helper-simple-access@7.16.0/lib/index.js',      '@babel/helper-module-imports': 'https://ga.jspm.io/npm:@babel/helper-module-imports@7.16.0/lib/index.js',
+          '@babel/helper-simple-access': 'https://ga.jspm.io/npm:@babel/helper-simple-access@7.16.0/lib/index.js', '@babel/helper-module-imports': 'https://ga.jspm.io/npm:@babel/helper-module-imports@7.16.0/lib/index.js',
           '@babel/helper-replace-supers': 'https://ga.jspm.io/npm:@babel/helper-replace-supers@7.16.0/lib/index.js'
         },
         'https://ga.jspm.io/npm:@babel/helper-optimise-call-expression@7.16.0/': {
@@ -306,17 +307,17 @@ import { deepStrictEqual } from 'assert';
           chalk: 'https://ga.jspm.io/npm:chalk@2.4.2/index.js'
         },
         'https://ga.jspm.io/npm:@babel/plugin-syntax-typescript@7.16.0/': {
-          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js'   
+          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js'
         },
         'https://ga.jspm.io/npm:@babel/plugin-transform-typescript@7.16.0/': {
-          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',  
+          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',
           assert: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/assert.js',
           '@babel/core': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/dev.index.js',
           '@babel/plugin-syntax-typescript': 'https://ga.jspm.io/npm:@babel/plugin-syntax-typescript@7.16.0/lib/index.js',
           '@babel/helper-create-class-features-plugin': 'https://ga.jspm.io/npm:@babel/helper-create-class-features-plugin@7.16.0/lib/index.js'
         },
         'https://ga.jspm.io/npm:@babel/preset-typescript@7.16.0/': {
-          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',  
+          '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',
           '@babel/helper-validator-option': 'https://ga.jspm.io/npm:@babel/helper-validator-option@7.14.5/lib/index.js',
           '@babel/plugin-transform-typescript': 'https://ga.jspm.io/npm:@babel/plugin-transform-typescript@7.16.0/lib/index.js'
         },
@@ -334,7 +335,7 @@ import { deepStrictEqual } from 'assert';
           '@babel/helper-split-export-declaration': 'https://ga.jspm.io/npm:@babel/helper-split-export-declaration@7.16.0/lib/index.js',
           globals: 'https://ga.jspm.io/npm:globals@11.12.0/index.js',
           '@babel/helper-hoist-variables': 'https://ga.jspm.io/npm:@babel/helper-hoist-variables@7.16.0/lib/index.js',
-          '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js' 
+          '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js'
         },
         'https://ga.jspm.io/npm:@babel/types@7.16.0/': {
           process: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/process.js',
@@ -350,7 +351,7 @@ import { deepStrictEqual } from 'assert';
           '#node.js': 'https://ga.jspm.io/npm:browserslist@4.17.4/browser.js',
           'node-releases/data/processed/envs.json': 'https://ga.jspm.io/npm:node-releases@2.0.1/data/processed/envs.json.js',
           'node-releases/data/release-schedule/release-schedule.json': 'https://ga.jspm.io/npm:node-releases@2.0.1/data/release-schedule/release-schedule.json.js',
-          'electron-to-chromium/versions': 'https://ga.jspm.io/npm:electron-to-chromium@1.3.886/versions.js',     
+          'electron-to-chromium/versions': 'https://ga.jspm.io/npm:electron-to-chromium@1.3.886/versions.js',
           'caniuse-lite/dist/unpacker/agents': 'https://ga.jspm.io/npm:caniuse-lite@1.0.30001274/dist/unpacker/agents.js'
         },
         'https://ga.jspm.io/npm:chalk@2.4.2/': {
@@ -385,13 +386,13 @@ import { deepStrictEqual } from 'assert';
     }
   });
   map.flatten();
-  deepStrictEqual(map.toJSON(),{
+  deepStrictEqual(map.toJSON(), {
     imports: { '@jspm/generator': '../../dist/generator.js' },
     scopes: {
       '../../': {
         '#fetch': '../../dist/fetch-native.js',
         '@babel/core': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/dev.index.js',
-        '@babel/preset-typescript': 'https://ga.jspm.io/npm:@babel/preset-typescript@7.16.0/lib/index.js',      
+        '@babel/preset-typescript': 'https://ga.jspm.io/npm:@babel/preset-typescript@7.16.0/lib/index.js',
         '@jspm/import-map': 'https://ga.jspm.io/npm:@jspm/import-map@0.1.5/dist/map.js',
         'es-module-lexer': 'https://ga.jspm.io/npm:es-module-lexer@0.9.3/dist/lexer.js',
         fs: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/fs.js',
@@ -402,7 +403,7 @@ import { deepStrictEqual } from 'assert';
       'https://ga.jspm.io/': {
         '#lib/config/files/index.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/config/files/index-browser.js',
         '#lib/config/resolve-targets.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/config/resolve-targets-browser.js',
-        '#lib/transform-file.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transform-file-browser.js',    
+        '#lib/transform-file.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transform-file-browser.js',
         '#lib/transformation/util/clone-deep.js': 'https://ga.jspm.io/npm:@babel/core@7.16.0/lib/transformation/util/clone-deep-browser.js',
         '#node.js': 'https://ga.jspm.io/npm:browserslist@4.17.4/browser.js',
         '@babel/code-frame': 'https://ga.jspm.io/npm:@babel/code-frame@7.16.0/lib/index.js',
@@ -413,13 +414,13 @@ import { deepStrictEqual } from 'assert';
         '@babel/helper-annotate-as-pure': 'https://ga.jspm.io/npm:@babel/helper-annotate-as-pure@7.16.0/lib/index.js',
         '@babel/helper-compilation-targets': 'https://ga.jspm.io/npm:@babel/helper-compilation-targets@7.16.0/lib/index.js',
         '@babel/helper-create-class-features-plugin': 'https://ga.jspm.io/npm:@babel/helper-create-class-features-plugin@7.16.0/lib/index.js',
-        '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js',      '@babel/helper-get-function-arity': 'https://ga.jspm.io/npm:@babel/helper-get-function-arity@7.16.0/lib/index.js',
+        '@babel/helper-function-name': 'https://ga.jspm.io/npm:@babel/helper-function-name@7.16.0/lib/index.js', '@babel/helper-get-function-arity': 'https://ga.jspm.io/npm:@babel/helper-get-function-arity@7.16.0/lib/index.js',
         '@babel/helper-hoist-variables': 'https://ga.jspm.io/npm:@babel/helper-hoist-variables@7.16.0/lib/index.js',
         '@babel/helper-member-expression-to-functions': 'https://ga.jspm.io/npm:@babel/helper-member-expression-to-functions@7.16.0/lib/index.js',
         '@babel/helper-module-imports': 'https://ga.jspm.io/npm:@babel/helper-module-imports@7.16.0/lib/index.js',
         '@babel/helper-module-transforms': 'https://ga.jspm.io/npm:@babel/helper-module-transforms@7.16.0/lib/index.js',
         '@babel/helper-optimise-call-expression': 'https://ga.jspm.io/npm:@babel/helper-optimise-call-expression@7.16.0/lib/index.js',
-        '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',  
+        '@babel/helper-plugin-utils': 'https://ga.jspm.io/npm:@babel/helper-plugin-utils@7.14.5/lib/index.js',
         '@babel/helper-replace-supers': 'https://ga.jspm.io/npm:@babel/helper-replace-supers@7.16.0/lib/index.js',
         '@babel/helper-simple-access': 'https://ga.jspm.io/npm:@babel/helper-simple-access@7.16.0/lib/index.js',
         '@babel/helper-split-export-declaration': 'https://ga.jspm.io/npm:@babel/helper-split-export-declaration@7.16.0/lib/index.js',
@@ -443,7 +444,7 @@ import { deepStrictEqual } from 'assert';
         'color-name': 'https://ga.jspm.io/npm:color-name@1.1.3/index.js',
         'convert-source-map': 'https://ga.jspm.io/npm:convert-source-map@1.8.0/index.js',
         debug: 'https://ga.jspm.io/npm:debug@4.3.2/src/browser.js',
-        'electron-to-chromium/versions': 'https://ga.jspm.io/npm:electron-to-chromium@1.3.886/versions.js',     
+        'electron-to-chromium/versions': 'https://ga.jspm.io/npm:electron-to-chromium@1.3.886/versions.js',
         'escape-string-regexp': 'https://ga.jspm.io/npm:escape-string-regexp@1.0.5/index.js',
         fs: 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.12/nodelibs/browser/fs.js',
         gensync: 'https://ga.jspm.io/npm:gensync@1.0.0-beta.2/index.js',


### PR DESCRIPTION
A fix for `bennyp`'s issue on Discord. We're treating the result of `resolve()`
as an absolute URL, but it might be a relative if we try to resolve a root-relative
without a `rootUrl` being set. I've run all the generator tests on this patch
as well and found no regressions.
