### PR TITLE
chore: release packages to `npm` on tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,15 +9,12 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [16.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node }}
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node: ${{ matrix.node }}
+          node-version: "16.x"
       - name: Setup Chomp
         uses: guybedford/chomp-action@v1
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  test-node:
+    name: Node.js Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14.x, 16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node: ${{ matrix.node }}
+      - name: Setup Chomp
+        uses: guybedford/chomp-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Installing Dependencies
+        run: npm install
+      - name: Build package
+        run: chomp build
+      - name: Run tests
+        run: chomp test
+
+  publish:
+    name: Publish package to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          node: 16.x
+      - name: Authenticate with Registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm logout
+          echo "@jspm:registry=https://registry.npmjs.org/" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+          npm whoami
+
+      - name: Publish to npm
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,12 @@ on:
       - "*"
 
 jobs:
-  test-node:
-    name: Node.js Tests
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x, 16.x]
+        node: [16.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node }}
@@ -28,14 +28,6 @@ jobs:
         run: chomp build
       - name: Run tests
         run: chomp test
-
-  publish:
-    name: Publish package to npm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          node: 16.x
       - name: Authenticate with Registry
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
@guybedford added the publish workflow here. If all looks good, we can adopt the same to all projects. So, on tagging it will release the packages to npm. And we need to take care of only upgrading the dependents like
- @jspm/generator
- generator.jspm.io
- cli

And follows depending on the sequence.